### PR TITLE
remove tape-run (except for travis)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ notifications:
   email: false
 node_js:
   - 'node'
+  - 'lts/*'
 sudo: false
 cache:
   directories:
@@ -11,7 +12,10 @@ install:
   - export DISPLAY=':99.0'
   - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 before_script:
+- npm install tape-run
 - npm run bootstrap
+script:
+- npm run test:ci
 before_deploy:
 - npm run jsdoc
 deploy:
@@ -30,3 +34,5 @@ addons:
   apt:
     packages:
       - xvfb
+  chrome: stable
+  firefox: latest

--- a/README.md
+++ b/README.md
@@ -13,9 +13,15 @@
 
 > A geographic toolkit for dealing with geometry, geography, formats, and building geodatabases.
 
-See our website [@terraformer](http://terraformer.io) for more information.
+See the [@terraformer](https://terraformer-js.github.io/terraformer/module-@terraformer_spatial.html) website for more information.
 
-## Install
+## Packages
+
+* **[`@terraformer/spatial`](./packages/spatial/)** - Spatial predicates for [GeoJSON](https://tools.ietf.org/html/rfc7946).
+* **[`@terraformer/arcgis`](./packages/arcgis/)**  -  Convert ArcGIS JSON geometries to GeoJSON geometries and vice versa.
+* **`@terraformer/wkt`** - coming soon
+
+## Contributing
 
 ```shell
 npm install

--- a/package-lock.json
+++ b/package-lock.json
@@ -809,45 +809,6 @@
       "integrity": "sha512-gzAiePolEXlMlQxbHWcdmz+b+PEixO5so0mU8jMlCemp8sxUWko9AzWc4EK3MV6BCUYd9cjq+Gd477cZiq5Kfw==",
       "dev": true
     },
-    "@juliangruber/tap-finished": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@juliangruber/tap-finished/-/tap-finished-0.0.2.tgz",
-      "integrity": "sha1-qarWPV5EJf+KbZpqlKsoehtZXb4=",
-      "dev": true,
-      "requires": {
-        "once": "^1.3.3",
-        "tap-parser": "~0.2.0",
-        "through": "~2.3.4"
-      },
-      "dependencies": {
-        "split": {
-          "version": "0.1.2",
-          "resolved": "http://registry.npmjs.org/split/-/split-0.1.2.tgz",
-          "integrity": "sha1-8HEHRMRT1VH8cUPq2YPaYBTjNsw=",
-          "dev": true,
-          "requires": {
-            "through": "1"
-          },
-          "dependencies": {
-            "through": {
-              "version": "1.1.2",
-              "resolved": "http://registry.npmjs.org/through/-/through-1.1.2.tgz",
-              "integrity": "sha1-NEpUJaN3MxTKfg62US+6+vdsC/4=",
-              "dev": true
-            }
-          }
-        },
-        "tap-parser": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-0.2.1.tgz",
-          "integrity": "sha1-jh6CPyEU7iHQMuLzHk+2QqKW9Qs=",
-          "dev": true,
-          "requires": {
-            "split": "~0.1.2"
-          }
-        }
-      }
-    },
     "@types/estree": {
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
@@ -1127,12 +1088,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
-    },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
       "dev": true
     },
     "asn1": {
@@ -1509,38 +1464,6 @@
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
       "dev": true
     },
-    "browser-launcher": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/browser-launcher/-/browser-launcher-1.0.1.tgz",
-      "integrity": "sha512-XLZ96W4jzKOBMcrE7juOusdiIzbZRG3q/sPGh5ytZJSJ7/JndKqoUjfHdiXFzxILidIjsj79rCKUHAIKxJCUCw==",
-      "dev": true,
-      "requires": {
-        "headless": "~0.1.3",
-        "minimist": "0.0.5",
-        "mkdirp": "~0.3.3",
-        "plist": "0.2.1",
-        "xtend": "^4.0.0"
-      },
-      "dependencies": {
-        "headless": {
-          "version": "0.1.3",
-          "bundled": true,
-          "dev": true
-        },
-        "minimist": {
-          "version": "0.0.5",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.5.tgz",
-          "integrity": "sha1-16oye87PUY+RBqxrjwA/o7zqhWY=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.3.5",
-          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
-          "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc=",
-          "dev": true
-        }
-      }
-    },
     "browser-pack": {
       "version": "6.1.0",
       "resolved": "http://registry.npmjs.org/browser-pack/-/browser-pack-6.1.0.tgz",
@@ -1569,38 +1492,6 @@
           "resolved": "http://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
           "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
           "dev": true
-        }
-      }
-    },
-    "browser-run": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/browser-run/-/browser-run-5.0.1.tgz",
-      "integrity": "sha512-5fWPcJACcgaeOms6xXcHLXEoPTlze63EV8vKd1qxGqksNvaARLeKSUxdCfS+MTQvtBYEXgkkcH/FhR6QHgWzKg==",
-      "dev": true,
-      "requires": {
-        "browser-launcher": "^1.0.1",
-        "duplexer": "^0.1.1",
-        "ecstatic": "^2.0.0",
-        "electron-stream": "^5.1.1",
-        "enstore": "^1.0.1",
-        "html-inject-script": "^1.1.0",
-        "optimist": "^0.6.1",
-        "phantomjs-stream": "^1.1.1",
-        "server-destroy": "^1.0.1",
-        "source-map-support": "^0.4.0",
-        "through": "^2.3.8",
-        "xhr-write-stream": "^0.1.2",
-        "xtend": "^4.0.1"
-      },
-      "dependencies": {
-        "source-map-support": {
-          "version": "0.4.18",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-          "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-          "dev": true,
-          "requires": {
-            "source-map": "^0.5.6"
-          }
         }
       }
     },
@@ -2631,15 +2522,6 @@
       "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
       "dev": true
     },
-    "cssauron": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/cssauron/-/cssauron-1.4.0.tgz",
-      "integrity": "sha1-pmAt/34EqDBtwNuaVR6S6LVmKtg=",
-      "dev": true,
-      "requires": {
-        "through": "X.X.X"
-      }
-    },
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -2902,16 +2784,6 @@
         }
       }
     },
-    "dezalgo": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
-      "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
-      "dev": true,
-      "requires": {
-        "asap": "^2.0.0",
-        "wrappy": "1"
-      }
-    },
     "diffie-hellman": {
       "version": "5.0.3",
       "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
@@ -2978,135 +2850,6 @@
         "safer-buffer": "^2.1.0"
       }
     },
-    "ecstatic": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-2.2.1.tgz",
-      "integrity": "sha512-ztE4WqheoWLh3wv+HQwy7dACnvNY620coWpa+XqY6R2cVWgaAT2lUISU1Uf7JpdLLJCURktJOaA9av2AOzsyYQ==",
-      "dev": true,
-      "requires": {
-        "he": "^1.1.1",
-        "mime": "^1.2.11",
-        "minimist": "^1.1.0",
-        "url-join": "^2.0.2"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
-      }
-    },
-    "electron": {
-      "version": "1.8.8",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-1.8.8.tgz",
-      "integrity": "sha512-1f9zJehcTTGjrkb06o6ds+gsRq6SYhZJyxOk6zIWjRH8hVy03y/RzUDELzNas71f5vcvXmfGVvyjeEsadDI8tg==",
-      "dev": true,
-      "requires": {
-        "@types/node": "^8.0.24",
-        "electron-download": "^3.0.1",
-        "extract-zip": "^1.0.3"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "8.10.39",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.39.tgz",
-          "integrity": "sha512-rE7fktr02J8ybFf6eysife+WF+L4sAHWzw09DgdCebEu+qDwMvv4zl6Bc+825ttGZP73kCKxa3dhJOoGJ8+5mA==",
-          "dev": true
-        }
-      }
-    },
-    "electron-download": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/electron-download/-/electron-download-3.3.0.tgz",
-      "integrity": "sha1-LP1U1pZsAZxNSa1l++Zcyc3vaMg=",
-      "dev": true,
-      "requires": {
-        "debug": "^2.2.0",
-        "fs-extra": "^0.30.0",
-        "home-path": "^1.0.1",
-        "minimist": "^1.2.0",
-        "nugget": "^2.0.0",
-        "path-exists": "^2.1.0",
-        "rc": "^1.1.2",
-        "semver": "^5.3.0",
-        "sumchecker": "^1.2.0"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "0.30.0",
-          "resolved": "http://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
-          "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^2.1.0",
-            "klaw": "^1.0.0",
-            "path-is-absolute": "^1.0.0",
-            "rimraf": "^2.2.8"
-          }
-        },
-        "jsonfile": {
-          "version": "2.4.0",
-          "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "^2.0.0"
-          }
-        }
-      }
-    },
-    "electron-stream": {
-      "version": "5.1.2",
-      "resolved": "http://registry.npmjs.org/electron-stream/-/electron-stream-5.1.2.tgz",
-      "integrity": "sha512-r21cChsfIVdVKPp76xNk7Gs+Rjib2EyJEWKlQntvTm5+XYtX8GtXNFY1Wa9ZkYBiWby5W143zRWbDbzWqAiZkA==",
-      "dev": true,
-      "requires": {
-        "debug": "^2.6.1",
-        "ecstatic": "^3.0.0",
-        "electron": "^1.8.4",
-        "json-stringify-safe": "^5.0.1",
-        "stream-read": "^1.1.2",
-        "tempy": "0.1.0"
-      },
-      "dependencies": {
-        "ecstatic": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-3.3.0.tgz",
-          "integrity": "sha512-EblWYTd+wPIAMQ0U4oYJZ7QBypT9ZUIwpqli0bKDjeIIQnXDBK2dXtZ9yzRCOlkW1HkO8gn7/FxLK1yPIW17pw==",
-          "dev": true,
-          "requires": {
-            "he": "^1.1.1",
-            "mime": "^1.6.0",
-            "minimist": "^1.1.0",
-            "url-join": "^2.0.5"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
-      }
-    },
     "electron-to-chromium": {
       "version": "1.3.96",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.96.tgz",
@@ -3126,15 +2869,6 @@
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.0"
-      }
-    },
-    "enstore": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/enstore/-/enstore-1.0.1.tgz",
-      "integrity": "sha1-og/nHq696KOBOgoSQEdfVYVKgas=",
-      "dev": true,
-      "requires": {
-        "monotonic-timestamp": "0.0.8"
       }
     },
     "error-ex": {
@@ -3169,12 +2903,6 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
-    },
-    "es6-promise": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
-      "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg==",
-      "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -3835,18 +3563,6 @@
         }
       }
     },
-    "extract-zip": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
-      "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
-      "dev": true,
-      "requires": {
-        "concat-stream": "1.6.2",
-        "debug": "2.6.9",
-        "mkdirp": "0.5.1",
-        "yauzl": "2.4.1"
-      }
-    },
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -3955,15 +3671,6 @@
             "object-keys": "~0.4.0"
           }
         }
-      }
-    },
-    "fd-slicer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
-      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
-      "dev": true,
-      "requires": {
-        "pend": "~1.2.0"
       }
     },
     "figures": {
@@ -5220,12 +4927,6 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
-    "he": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "dev": true
-    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -5243,12 +4944,6 @@
       "integrity": "sha1-V6j+JM8zzdUkhgoVgh3cJchmcfs=",
       "dev": true
     },
-    "home-path": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/home-path/-/home-path-1.0.6.tgz",
-      "integrity": "sha512-wo+yjrdAtoXt43Vy92a+0IPCYViiyLAHyp0QVS4xL/tfvVz5sXIW1ubLZk3nhVkD92fQpUMKX+fzMjr5F489vw==",
-      "dev": true
-    },
     "homedir-polyfill": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
@@ -5263,156 +4958,6 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
       "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
       "dev": true
-    },
-    "html-inject-script": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/html-inject-script/-/html-inject-script-1.1.0.tgz",
-      "integrity": "sha1-GnwQoPy9MJ6Fv1PZpe0kt0xeMnU=",
-      "dev": true,
-      "requires": {
-        "trumpet": "^1.7.1"
-      }
-    },
-    "html-select": {
-      "version": "2.3.24",
-      "resolved": "https://registry.npmjs.org/html-select/-/html-select-2.3.24.tgz",
-      "integrity": "sha1-Rq1tcS5zLPMcZznV0BEKX6vxdYU=",
-      "dev": true,
-      "requires": {
-        "cssauron": "^1.1.0",
-        "duplexer2": "~0.0.2",
-        "inherits": "^2.0.1",
-        "minimist": "~0.0.8",
-        "readable-stream": "^1.0.27-1",
-        "split": "~0.3.0",
-        "stream-splicer": "^1.2.0",
-        "through2": "^1.0.0"
-      },
-      "dependencies": {
-        "duplexer2": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-          "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
-          "dev": true,
-          "requires": {
-            "readable-stream": "~1.1.9"
-          }
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "split": {
-          "version": "0.3.3",
-          "resolved": "http://registry.npmjs.org/split/-/split-0.3.3.tgz",
-          "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
-          "dev": true,
-          "requires": {
-            "through": "2"
-          }
-        },
-        "stream-splicer": {
-          "version": "1.3.2",
-          "resolved": "http://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.2.tgz",
-          "integrity": "sha1-PARBvhW5v04iYnXm3IOWR0VUZmE=",
-          "dev": true,
-          "requires": {
-            "indexof": "0.0.1",
-            "inherits": "^2.0.1",
-            "isarray": "~0.0.1",
-            "readable-stream": "^1.1.13-1",
-            "readable-wrap": "^1.0.0",
-            "through2": "^1.0.0"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        },
-        "through2": {
-          "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
-          "integrity": "sha1-CEfLxESfNAVXTb3M2buEG4OsNUU=",
-          "dev": true,
-          "requires": {
-            "readable-stream": ">=1.1.13-1 <1.2.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
-          }
-        }
-      }
-    },
-    "html-tokenize": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/html-tokenize/-/html-tokenize-1.2.5.tgz",
-      "integrity": "sha1-flupnstR75Buyaf83ubKMmfHiX4=",
-      "dev": true,
-      "requires": {
-        "inherits": "~2.0.1",
-        "minimist": "~0.0.8",
-        "readable-stream": "~1.0.27-1",
-        "through2": "~0.4.1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        },
-        "through2": {
-          "version": "0.4.2",
-          "resolved": "http://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
-          "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
-          "dev": true,
-          "requires": {
-            "readable-stream": "~1.0.17",
-            "xtend": "~2.1.1"
-          }
-        },
-        "xtend": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-          "dev": true,
-          "requires": {
-            "object-keys": "~0.4.0"
-          }
-        }
-      }
     },
     "htmlescape": {
       "version": "1.1.1",
@@ -5543,12 +5088,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
       "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
-      "dev": true
-    },
-    "indexof": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
       "dev": true
     },
     "inflight": {
@@ -6225,15 +5764,6 @@
       "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
       "dev": true
     },
-    "klaw": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
-      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.9"
-      }
-    },
     "labeled-stream-splicer": {
       "version": "2.0.1",
       "resolved": "http://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.1.tgz",
@@ -6870,12 +6400,6 @@
       "integrity": "sha512-3IE39bHVqFbWWaPOMHZF98Q9c3LDKGTmypMiTM2QygGXXElkFWIH7GxfmlwmY2vwa+wmNsoYZmG2iusf1ZjJoA==",
       "dev": true
     },
-    "monotonic-timestamp": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/monotonic-timestamp/-/monotonic-timestamp-0.0.8.tgz",
-      "integrity": "sha1-Z5h9AqQcFfVotsCgWIWYndJAK6A=",
-      "dev": true
-    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -6981,88 +6505,6 @@
         "console-control-strings": "~1.1.0",
         "gauge": "~2.7.3",
         "set-blocking": "~2.0.0"
-      }
-    },
-    "nugget": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/nugget/-/nugget-2.0.1.tgz",
-      "integrity": "sha1-IBCVpIfhrTYIGzQy+jytpPjQcbA=",
-      "dev": true,
-      "requires": {
-        "debug": "^2.1.3",
-        "minimist": "^1.1.0",
-        "pretty-bytes": "^1.0.2",
-        "progress-stream": "^1.1.0",
-        "request": "^2.45.0",
-        "single-line-log": "^1.1.2",
-        "throttleit": "0.0.2"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        },
-        "progress-stream": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/progress-stream/-/progress-stream-1.2.0.tgz",
-          "integrity": "sha1-LNPP6jO6OonJwSHsM0er6asSX3c=",
-          "dev": true,
-          "requires": {
-            "speedometer": "~0.1.2",
-            "through2": "~0.2.3"
-          }
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "speedometer": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/speedometer/-/speedometer-0.1.4.tgz",
-          "integrity": "sha1-mHbb0qFp0xFUAtSObqYynIgWpQ0=",
-          "dev": true
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        },
-        "through2": {
-          "version": "0.2.3",
-          "resolved": "http://registry.npmjs.org/through2/-/through2-0.2.3.tgz",
-          "integrity": "sha1-6zKE2k6jEbbMis42U3SKUqvyWj8=",
-          "dev": true,
-          "requires": {
-            "readable-stream": "~1.1.9",
-            "xtend": "~2.1.1"
-          }
-        },
-        "xtend": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-          "dev": true,
-          "requires": {
-            "object-keys": "~0.4.0"
-          }
-        }
       }
     },
     "number-is-nan": {
@@ -7239,12 +6681,6 @@
           "dev": true
         }
       }
-    },
-    "ordered-emitter": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ordered-emitter/-/ordered-emitter-0.1.1.tgz",
-      "integrity": "sha1-qiC9r73MFjGDSjUPaLTvjrNO7Xs=",
-      "dev": true
     },
     "os-browserify": {
       "version": "0.3.0",
@@ -7477,26 +6913,11 @@
         "sha.js": "^2.4.8"
       }
     },
-    "pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
-      "dev": true
-    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
-    },
-    "phantomjs-stream": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/phantomjs-stream/-/phantomjs-stream-1.1.1.tgz",
-      "integrity": "sha1-VlD0ICjAnoRrxGO4K/TK/EOjuis=",
-      "dev": true,
-      "requires": {
-        "stream-read": "^1.1.2"
-      }
     },
     "pify": {
       "version": "3.0.0",
@@ -7558,15 +6979,6 @@
         "find-up": "^2.1.0"
       }
     },
-    "plist": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/plist/-/plist-0.2.1.tgz",
-      "integrity": "sha1-86PeB4hddz5m2KlngvG+wozystA=",
-      "dev": true,
-      "requires": {
-        "sax": "0.1.x"
-      }
-    },
     "pluralize": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
@@ -7596,98 +7008,6 @@
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true
-    },
-    "pretty-bytes": {
-      "version": "1.0.4",
-      "resolved": "http://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
-      "integrity": "sha1-CiLoIQYJrTVUL4yNXSFZr/B1HIQ=",
-      "dev": true,
-      "requires": {
-        "get-stdin": "^4.0.1",
-        "meow": "^3.1.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-          "dev": true
-        },
-        "camelcase-keys": {
-          "version": "2.1.0",
-          "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-          "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-          "dev": true,
-          "requires": {
-            "camelcase": "^2.0.0",
-            "map-obj": "^1.0.0"
-          }
-        },
-        "indent-string": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-          "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-          "dev": true,
-          "requires": {
-            "repeating": "^2.0.0"
-          }
-        },
-        "map-obj": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-          "dev": true
-        },
-        "meow": {
-          "version": "3.7.0",
-          "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-          "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-          "dev": true,
-          "requires": {
-            "camelcase-keys": "^2.0.0",
-            "decamelize": "^1.1.2",
-            "loud-rejection": "^1.0.0",
-            "map-obj": "^1.0.1",
-            "minimist": "^1.1.3",
-            "normalize-package-data": "^2.3.4",
-            "object-assign": "^4.0.1",
-            "read-pkg-up": "^1.0.1",
-            "redent": "^1.0.0",
-            "trim-newlines": "^1.0.0"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        },
-        "redent": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-          "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-          "dev": true,
-          "requires": {
-            "indent-string": "^2.1.0",
-            "strip-indent": "^1.0.1"
-          }
-        },
-        "strip-indent": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-          "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-          "dev": true,
-          "requires": {
-            "get-stdin": "^4.0.1"
-          }
-        },
-        "trim-newlines": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-          "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-          "dev": true
-        }
-      }
     },
     "private": {
       "version": "0.1.8",
@@ -7994,41 +7314,6 @@
         "safe-buffer": "~5.1.1",
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
-      }
-    },
-    "readable-wrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz",
-      "integrity": "sha1-O1ohHGMeEjA6VJkcgGwX564ga/8=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "^1.1.13-1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        }
       }
     },
     "readdirp": {
@@ -8528,12 +7813,6 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
-    "sax": {
-      "version": "0.1.5",
-      "resolved": "http://registry.npmjs.org/sax/-/sax-0.1.5.tgz",
-      "integrity": "sha1-0YKaYSD6AWZetNv/bEPyn9bWFHE=",
-      "dev": true
-    },
     "semistandard": {
       "version": "13.0.1",
       "resolved": "https://registry.npmjs.org/semistandard/-/semistandard-13.0.1.tgz",
@@ -8566,12 +7845,6 @@
       "requires": {
         "semver": "^5.0.3"
       }
-    },
-    "server-destroy": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
-      "integrity": "sha1-8Tv5KOQrnD55OD5hzDmYtdFObN0=",
-      "dev": true
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -8666,15 +7939,6 @@
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
       "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
       "dev": true
-    },
-    "single-line-log": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/single-line-log/-/single-line-log-1.1.2.tgz",
-      "integrity": "sha1-wvg/Jzo+GhbtsJlWYdoO1e8DM2Q=",
-      "dev": true,
-      "requires": {
-        "string-width": "^1.0.1"
-      }
     },
     "slash": {
       "version": "2.0.0",
@@ -9090,15 +8354,6 @@
         "xtend": "^4.0.0"
       }
     },
-    "stream-read": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/stream-read/-/stream-read-1.1.2.tgz",
-      "integrity": "sha1-MTcRDXqoC6VOS4KcTNM8oQa5Vk0=",
-      "dev": true,
-      "requires": {
-        "dezalgo": "^1.0.1"
-      }
-    },
     "stream-splicer": {
       "version": "2.0.0",
       "resolved": "http://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.0.tgz",
@@ -9209,16 +8464,6 @@
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
-      }
-    },
-    "sumchecker": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-1.3.1.tgz",
-      "integrity": "sha1-ebs7RFbdBPGOvbwNcDodHa7FEF0=",
-      "dev": true,
-      "requires": {
-        "debug": "^2.2.0",
-        "es6-promise": "^4.0.5"
       }
     },
     "supports-color": {
@@ -9378,19 +8623,6 @@
         }
       }
     },
-    "tape-run": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/tape-run/-/tape-run-5.0.0.tgz",
-      "integrity": "sha512-7R2QB0WjN1Lstfvh35UxL6vxNaXfNIAaL6/tunZ+H72mxSs4SOorsanv3slFTuasoeFhA1zSIzBCPeHfxsfOgA==",
-      "dev": true,
-      "requires": {
-        "@juliangruber/tap-finished": "0.0.2",
-        "browser-run": "^5.0.1",
-        "optimist": "~0.6.1",
-        "through": "~2.3.4",
-        "throughout": "0.0.0"
-      }
-    },
     "temp-dir": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
@@ -9429,25 +8661,6 @@
         }
       }
     },
-    "tempy": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/tempy/-/tempy-0.1.0.tgz",
-      "integrity": "sha1-hSdBPNBxAINPzJy7gkK+lboOH+4=",
-      "dev": true,
-      "requires": {
-        "pify": "^2.3.0",
-        "temp-dir": "^1.0.0",
-        "unique-string": "^1.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        }
-      }
-    },
     "term-size": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
@@ -9469,12 +8682,6 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
-    "throttleit": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
-      "integrity": "sha1-z+34jmDADdlpe2H90qg0OptoDq8=",
-      "dev": true
-    },
     "through": {
       "version": "2.3.8",
       "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -9489,24 +8696,6 @@
       "requires": {
         "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
-      }
-    },
-    "throughout": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/throughout/-/throughout-0.0.0.tgz",
-      "integrity": "sha1-2pNVJyMaeUTapg061HoyQprxqME=",
-      "dev": true,
-      "requires": {
-        "duplexer": "~0.0.2",
-        "through": "~2.3.4"
-      },
-      "dependencies": {
-        "duplexer": {
-          "version": "0.0.4",
-          "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.0.4.tgz",
-          "integrity": "sha1-r8t/H4uNdPggcmFx1dZKyeSo/yA=",
-          "dev": true
-        }
       }
     },
     "timed-out": {
@@ -9620,65 +8809,6 @@
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
-    },
-    "trumpet": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/trumpet/-/trumpet-1.7.2.tgz",
-      "integrity": "sha1-sCxp5GXRcfVeRJJL+bW90gl0yDA=",
-      "dev": true,
-      "requires": {
-        "duplexer2": "~0.0.2",
-        "html-select": "^2.3.5",
-        "html-tokenize": "^1.1.1",
-        "inherits": "^2.0.0",
-        "readable-stream": "^1.0.27-1",
-        "through2": "^1.0.0"
-      },
-      "dependencies": {
-        "duplexer2": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-          "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
-          "dev": true,
-          "requires": {
-            "readable-stream": "~1.1.9"
-          }
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        },
-        "through2": {
-          "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
-          "integrity": "sha1-CEfLxESfNAVXTb3M2buEG4OsNUU=",
-          "dev": true,
-          "requires": {
-            "readable-stream": ">=1.1.13-1 <1.2.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
-          }
-        }
-      }
     },
     "tslib": {
       "version": "1.9.3",
@@ -9985,12 +9115,6 @@
         }
       }
     },
-    "url-join": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-2.0.5.tgz",
-      "integrity": "sha1-WvIvGMBSoACkjXuCxenC4v7tpyg=",
-      "dev": true
-    },
     "url-parse-lax": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
@@ -10216,24 +9340,6 @@
       "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
       "dev": true
     },
-    "xhr-write-stream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/xhr-write-stream/-/xhr-write-stream-0.1.2.tgz",
-      "integrity": "sha1-41eEjg0Dm0Ef3Vs7+BvkfuXOJqo=",
-      "dev": true,
-      "requires": {
-        "concat-stream": "~0.1.0",
-        "ordered-emitter": "~0.1.0"
-      },
-      "dependencies": {
-        "concat-stream": {
-          "version": "0.1.1",
-          "resolved": "http://registry.npmjs.org/concat-stream/-/concat-stream-0.1.1.tgz",
-          "integrity": "sha1-1/TieLkM/E8PPvd/5MA7QOs/eQA=",
-          "dev": true
-        }
-      }
-    },
     "xmlcreate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-1.0.2.tgz",
@@ -10274,15 +9380,6 @@
       "dev": true,
       "requires": {
         "camelcase": "^4.1.0"
-      }
-    },
-    "yauzl": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
-      "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
-      "dev": true,
-      "requires": {
-        "fd-slicer": "~1.0.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -10,8 +10,11 @@
     "docs:serve": "http-server & onchange -v 'packages/**/*.js' -- npm run jsdoc",
     "lint": "semistandard | snazzy",
     "test:node": "node test-helper.js",
-    "test:browser": "browserify packages/**/test/*.js -t [ babelify --presets [ @babel/preset-env ] ] --debug | tape-run | faucet",
-    "test": "npm run lint && npm run test:browser && npm run test:node",
+    "test:electron": "browserify packages/**/test/*.js -t [ babelify --presets [ @babel/preset-env ] ] --debug | tape-run | faucet",
+    "test:chrome": "browserify packages/**/test/*.js -t [ babelify --presets [ @babel/preset-env ] ] --debug | tape-run --browser chrome | faucet",
+    "test:firefox": "browserify packages/**/test/*.js -t [ babelify --presets [ @babel/preset-env ] ] --debug | tape-run --browser firefox | faucet",
+    "test": "npm run lint && npm run test:node",
+    "test:ci": "npm run lint && npm run test:node && npm run test:chrome && npm run test:firefox",
     "release": "./release.sh"
   },
   "repository": {
@@ -47,7 +50,6 @@
     "rollup-plugin-node-resolve": "^4.0.0",
     "semistandard": "*",
     "snazzy": "^8.0.0",
-    "tape": "^4.0.0",
-    "tape-run": "^5.0.0"
+    "tape": "^4.0.0"
   }
 }


### PR DESCRIPTION
* `npm test` runs unit tests in whatever version of Node.js is installed locally.
* Travis runs unit tests in the current and LTS versions of Node.js
* Travis runs browser tests in Chrome and Firefox