### PR TITLE
Extend coordinate checks to accommodate z-value of `0`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: node_js
 notifications:
   email: false
 node_js:
-  - 'lts/*'
-  - 'node'
+  - 14
+  - 16
 sudo: false
 cache: npm
 before_script:

--- a/packages/arcgis/src/geojson.js
+++ b/packages/arcgis/src/geojson.js
@@ -59,42 +59,42 @@ export const geojsonToArcGIS = (geojson, idAttribute) => {
     case 'Point':
       result.x = geojson.coordinates[0];
       result.y = geojson.coordinates[1];
-      if (geojson.coordinates[2] || geojson.coordinates[2] === 0) {
+      if (geojson.coordinates[2] != null) {
         result.z = geojson.coordinates[2];
       }
       result.spatialReference = spatialReference;
       break;
     case 'MultiPoint':
       result.points = geojson.coordinates.slice(0);
-      if (geojson.coordinates[0][2] || geojson.coordinates[0][2] === 0) {
+      if (geojson.coordinates[0][2] != null) {
         result.hasZ = true;
       }
       result.spatialReference = spatialReference;
       break;
     case 'LineString':
       result.paths = [geojson.coordinates.slice(0)];
-      if (geojson.coordinates[0][2] || geojson.coordinates[0][2] === 0) {
+      if (geojson.coordinates[0][2] != null) {
         result.hasZ = true;
       }
       result.spatialReference = spatialReference;
       break;
     case 'MultiLineString':
       result.paths = geojson.coordinates.slice(0);
-      if (geojson.coordinates[0][0][2] || geojson.coordinates[0][0][2] === 0) {
+      if (geojson.coordinates[0][0][2] != null) {
         result.hasZ = true;
       }
       result.spatialReference = spatialReference;
       break;
     case 'Polygon':
       result.rings = orientRings(geojson.coordinates.slice(0));
-      if (geojson.coordinates[0][0][2] || geojson.coordinates[0][0][2] === 0) {
+      if (geojson.coordinates[0][0][2] != null) {
         result.hasZ = true;
       }
       result.spatialReference = spatialReference;
       break;
     case 'MultiPolygon':
       result.rings = flattenMultiPolygonRings(geojson.coordinates.slice(0));
-      if (geojson.coordinates[0][0][0][2] || geojson.coordinates[0][0][0][2] === 0) {
+      if (geojson.coordinates[0][0][0][2] != null) {
         result.hasZ = true;
       }
       result.spatialReference = spatialReference;

--- a/packages/arcgis/src/geojson.js
+++ b/packages/arcgis/src/geojson.js
@@ -59,42 +59,42 @@ export const geojsonToArcGIS = (geojson, idAttribute) => {
     case 'Point':
       result.x = geojson.coordinates[0];
       result.y = geojson.coordinates[1];
-      if (geojson.coordinates[2]) {
+      if (geojson.coordinates[2] || geojson.coordinates[2] === 0) {
         result.z = geojson.coordinates[2];
       }
       result.spatialReference = spatialReference;
       break;
     case 'MultiPoint':
       result.points = geojson.coordinates.slice(0);
-      if (geojson.coordinates[0][2]) {
+      if (geojson.coordinates[0][2] || geojson.coordinates[0][2] === 0) {
         result.hasZ = true;
       }
       result.spatialReference = spatialReference;
       break;
     case 'LineString':
       result.paths = [geojson.coordinates.slice(0)];
-      if (geojson.coordinates[0][2]) {
+      if (geojson.coordinates[0][2] || geojson.coordinates[0][2] === 0) {
         result.hasZ = true;
       }
       result.spatialReference = spatialReference;
       break;
     case 'MultiLineString':
       result.paths = geojson.coordinates.slice(0);
-      if (geojson.coordinates[0][0][2]) {
+      if (geojson.coordinates[0][0][2] || geojson.coordinates[0][0][2] === 0) {
         result.hasZ = true;
       }
       result.spatialReference = spatialReference;
       break;
     case 'Polygon':
       result.rings = orientRings(geojson.coordinates.slice(0));
-      if (geojson.coordinates[0][0][2]) {
+      if (geojson.coordinates[0][0][2] || geojson.coordinates[0][0][2] === 0) {
         result.hasZ = true;
       }
       result.spatialReference = spatialReference;
       break;
     case 'MultiPolygon':
       result.rings = flattenMultiPolygonRings(geojson.coordinates.slice(0));
-      if (geojson.coordinates[0][0][0][2]) {
+      if (geojson.coordinates[0][0][0][2] || geojson.coordinates[0][0][0][2] === 0) {
         result.hasZ = true;
       }
       result.spatialReference = spatialReference;

--- a/packages/arcgis/test/geojson.test.js
+++ b/packages/arcgis/test/geojson.test.js
@@ -45,6 +45,26 @@ test('should convert a GeoJSON Point to an ArcGIS Point and include z values', f
   });
 });
 
+test('should convert a GeoJSON Point to an ArcGIS Point and include a z value of 0', function (t) {
+  t.plan(1);
+
+  const input = {
+    type: 'Point',
+    coordinates: [-58.7109375, 47.4609375, 0]
+  };
+
+  var output = geojsonToArcGIS(input);
+
+  t.deepEqual(output, {
+    x: -58.7109375,
+    y: 47.4609375,
+    z: 0,
+    spatialReference: {
+      wkid: 4326
+    }
+  });
+});
+
 test('should convert a GeoJSON Null Island to an ArcGIS Point', function (t) {
   t.plan(1);
 


### PR DESCRIPTION
Hey @jgravois, this is a small fix for #78 that introduces an additional check so that z-values are not only checked for falsy, but also if equivalent to zero. 

If both checks fail, then it is certain that no z-values were included in the coordinates array. 

I added a new test in the same format as previous tests, but this time verifying persistence of the `0` z-value. Let me know if this needs enhanced at all, or if more coverage is required.

`npm run test` is successful after implementing these changes. 