### PR TITLE
Fix npm install for ArcGIS Terraformer README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@
 
   You'll do this:
   ```
-  npm install @terraformer/wkt
+  npm install @terraformer/arcgis
   ```
   ```js
   const { arcgisToGeoJSON, geojsonToArcGIS } from '@terraformer/arcgis'
@@ -129,7 +129,7 @@
   <summary>What about <code>terraformer-geostore</code>?</summary>
 
   This repo does **not** include a port of https://github.com/Esri/terraformer-geostore and there is no plan to tackle it in the future.
-  
+
   Since <code>terraformer-geostore</code> ingests plain ol' [GeoJSON](https://tools.ietf.org/html/rfc7946), you're welcome to keep on using the original code.
 </details>
 


### PR DESCRIPTION
Replace from `npm install @terraformer/wkt` to `npm install @terraformer/arcgis` in README for ArcGIS Terraformer.