### PR TITLE
fix #92 this.parseError is not a function

### DIFF
--- a/packages/wkt/src/wkt.js
+++ b/packages/wkt/src/wkt.js
@@ -7,6 +7,10 @@
 
 'SOURCE';
 
+parser.yy.parseError = function (err) {
+  throw err;
+};
+
 function PointArray (point) {
   this.data = [point];
   this.type = 'PointArray';

--- a/packages/wkt/src/wkt.js
+++ b/packages/wkt/src/wkt.js
@@ -7,6 +7,7 @@
 
 'SOURCE';
 
+// surface parsing errors to calling code https://github.com/zaach/jison/issues/218
 parser.yy.parseError = function (err) {
   throw err;
 };

--- a/packages/wkt/test/wkt.test.js
+++ b/packages/wkt/test/wkt.test.js
@@ -1035,3 +1035,16 @@ test('should parse a GEOMETRYCOLLECTION with ZM property', function (t) {
     }
   });
 });
+
+test('should fail with friendly error message when wkt is invalid', function (t) {
+  t.plan(1);
+
+  const input = 'POINT(30,10)';
+
+  try {
+    wktToGeoJSON(input);
+  } catch (err) {
+    const error = err.toString();
+    t.deepEqual(error, 'Error: Unable to parse: Parse error on line 1:\nPOINT(30,10)\n--------^\nExpecting \'DOUBLE_TOK\', got \'COMMA\'');
+  }
+});


### PR DESCRIPTION
By adding a `parseError` property to the parser.yy object we avoid the error `this.parseError is not a function` and we can re-throw the underlying error with a more useful error message.

This works because the `parser.yy` object gets copied to the `sharedState` object here:
https://github.com/zaach/jison/blob/master/lib/jison.js#L1393

Then because `sharedState.parseError` is defined it is used rather than undefined here:
https://github.com/zaach/jison/blob/master/lib/jison.js#L1409

Fixes #92 